### PR TITLE
Update add-in to support outlook instead of Excel documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,18 @@ page_type: sample
 urlFragment: office-add-in-auth-graph-react
 products:
   - office
-  - office-excel
-  - office-powerpoint
-  - office-word
+  - office-outlook
   - ms-graph
 languages:
   - javascript
-description: Learn how to build a Microsoft Office Add-in, as a single-page application with no backend, that connects to Microsoft Graph, finds the first three workbooks stored in OneDrive for Business, fetches their filenames, and inserts the names into an Office document using Office.js.
+description: Learn how to build a Microsoft Office Add-in, as a single-page application with no backend, that connects to Microsoft Graph, finds the first three workbooks stored in OneDrive for Business, fetches their filenames, and inserts the names into an email reply using Office.js.
 extensions:
   contentType: samples
   technologies:
     - Add-ins
     - Microsoft Graph
   services:
-    - Excel
+    - Outlook
     - Microsoft 365
   createdDate: 5/1/2017 2:09:09 PM
 ---
@@ -24,7 +22,7 @@ extensions:
 
 ## Summary
 
-Learn how to build a Microsoft Office Add-in, as a single-page application (SPA) with no backend, that connects to Microsoft Graph, finds the first three workbooks stored in OneDrive for Business, fetches their filenames, and inserts the names into an Office document using Office.js.
+Learn how to build a Microsoft Office Add-in, as a single-page application (SPA) with no backend, that connects to Microsoft Graph, finds the first three workbooks stored in OneDrive for Business, fetches their filenames, and inserts the names into an email reply using Office.js.
 
 ## Features
 
@@ -39,7 +37,7 @@ Integrating data from online service providers increases the value and adoption 
 
 ## Applies to
 
-* Excel on Windows (one-time purchase and subscription)
+* Outlook on Windows (one-time purchase and subscription)
 
 ## Prerequisites
 
@@ -84,7 +82,7 @@ Version  | Date | Comments
 1. Sign in with the ***admin*** credentials to your Microsoft 365 tenancy. For example, MyName@contoso.onmicrosoft.com.
 1. Select **New registration**. On the **Register an application** page, set the values as follows.
 
-    * Set **Name** to `ExcelGraphDemo`.
+    * Set **Name** to `OutlookGraphDemo`.
     * Set **Supported account types** to **Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)**.
     * In the **Redirect URI** section, ensure that **Single-page application (SPA)** is selected in the drop down and then set the URI to `https://localhost:3000/login/login.html`.
     * Select **Register**.
@@ -93,7 +91,7 @@ Version  | Date | Comments
 
     > Note: The sample uses the OAuth 2.0 Auth Code Flow w/ PKCE for SPAs, which requires no secrets.
 
-1. On the **ExcelGraphDemo** page, copy and save the value for the **Application (client) ID**. You'll use it in the next section.
+1. On the **OutlookGraphDemo** page, copy and save the value for the **Application (client) ID**. You'll use it in the next section.
 
 ### Configure the sample
 
@@ -113,7 +111,7 @@ Version  | Date | Comments
 ### Run the solution
 
 1. In the command prompt, run the command `start npm start`. This will open a second command prompt, build the project and then start a server (with dev mode settings). It takes from 5 to 30 seconds. When it finishes, the last line should say `Compiled successfully`. Minimize this command prompt.
-1. Back in the original command prompt, run the command `npm run sideload`. This will launch Excel and install the add-in in it. After a few seconds, a **OneDrive Files** group appears on the right end of the **Home** ribbon with a button named **Open Add-in**.
+1. Back in the original command prompt, run the command `npm run sideload`. This will launch Outlook and install the add-in in it. After a few seconds, a **OneDrive Files** group appears on the right end of the **Home** ribbon with a button named **Open Add-in**.
 1. Click the **Open Add-in** to open the task pane add-in.
 1. The pages and buttons in the add-in are self-explanatory. 
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -4,7 +4,7 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
           xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides"
-          xsi:type="MailApp">
+          xsi:type="TaskPaneApp">
 
   <!-- Begin Basic Settings: Add-in metadata, used for all versions of Office unless override provided. -->
 
@@ -34,50 +34,66 @@
   </AppDomains>
   <!--End Basic Settings. -->
 
-  <!--Begin Mail Integration. This section defines how your add-in integrates with Outlook. -->
+  <!--Begin TaskPane Mode integration. This section is used if there are no VersionOverrides or if the Office client version does not support add-in commands. -->
   <Hosts>
-    <Host Name="Mailbox" />
+    <Host Name="Workbook" />
   </Hosts>
+  <DefaultSettings>
+    <SourceLocation DefaultValue="https://localhost:3000/index.html" />
+  </DefaultSettings>
+  <!-- End TaskPane Mode integration.  -->
 
-  <Requirements>
-    <Sets DefaultMinVersion="1.1">
-      <Set Name="Mailbox" />
-    </Sets>
-  </Requirements>
-
-  <FormSettings>
-    <Form xsi:type="ItemRead">
-      <DesktopSettings>
-        <SourceLocation DefaultValue="https://localhost:3000/index.html" />
-      </DesktopSettings>
-    </Form>
-    <Form xsi:type="ItemEdit">
-      <DesktopSettings>
-        <SourceLocation DefaultValue="https://localhost:3000/index.html" />
-      </DesktopSettings>
-    </Form>
-  </FormSettings>
-
-  <Permissions>ReadWriteMailbox</Permissions>
+  <Permissions>ReadWriteDocument</Permissions>
 
   <!-- Begin Add-in Commands Mode integration. -->
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
 
     <!-- The Hosts node is required. -->
     <Hosts>
-      <!-- For Outlook, use Mailbox as the host type. -->
-      <Host xsi:type="Mailbox">
+      <!-- Each host can have a different set of commands. -->
+      <!-- Excel host is Workbook, Word host is Document, and PowerPoint host is Presentation. -->
+      <!-- Make sure the hosts you override match the hosts declared in the top section of the manifest. -->
+      <Host xsi:type="Workbook">
+        <!-- Form factor. Currently only DesktopFormFactor is supported. -->
         <DesktopFormFactor>
+          <!--"This code enables a customizable message to be displayed when the add-in is loaded successfully upon individual install."-->
+          <GetStarted>
+            <!-- Title of the Getting Started callout. resid points to a ShortString resource -->
+            <Title resid="Contoso.GetStarted.Title"/>
+
+            <!-- Description of the Getting Started callout. resid points to a LongString resource -->
+            <Description resid="Contoso.GetStarted.Description"/>
+
+            <!-- Point to a url resource which details how the add-in should be used. -->
+            <LearnMoreUrl resid="Contoso.GetStarted.LearnMoreUrl"/>
+          </GetStarted>
+          <!-- Function file is a HTML page that includes the JavaScript where functions for ExecuteAction will be called.
+            Think of the FunctionFile as the code behind ExecuteFunction. -->
           <FunctionFile resid="Contoso.DesktopFunctionFile.Url" />
 
-          <ExtensionPoint xsi:type="MessageReadCommandSurface">
-            <OfficeTab id="TabDefault">
+          <!-- PrimaryCommandSurface is the main Office Ribbon. -->
+          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+            <!-- Use OfficeTab to extend an existing Tab. Use CustomTab to create a new tab. -->
+            <OfficeTab id="TabHome">
+              <!-- Ensure you provide a unique id for the group. Recommendation for any IDs is to namespace using your company name. -->
               <Group id="Contoso.Group1">
+                <!-- Label for your group. resid must point to a ShortString resource. -->
                 <Label resid="Contoso.Group1Label" />
+                <!-- Icons. Required sizes 16,32,80, optional 20, 24, 40, 48, 64. Strongly recommended to provide all sizes for great UX. -->
+                <!-- Use PNG icons. All URLs on the resources section must use HTTPS. -->
+                <Icon>
+                  <bt:Image size="16" resid="Contoso.tpicon_16x16" />
+                  <bt:Image size="32" resid="Contoso.tpicon_32x32" />
+                  <bt:Image size="80" resid="Contoso.tpicon_80x80" />
+                </Icon>
+
+                <!-- Control. It can be of type "Button" or "Menu". -->
                 <Control xsi:type="Button" id="Contoso.TaskpaneButton">
                   <Label resid="Contoso.TaskpaneButton.Label" />
                   <Supertip>
+                    <!-- ToolTip title. resid must point to a ShortString resource. -->
                     <Title resid="Contoso.TaskpaneButton.Label" />
+                    <!-- ToolTip description. resid must point to a LongString resource. -->
                     <Description resid="Contoso.TaskpaneButton.Tooltip" />
                   </Supertip>
                   <Icon>
@@ -85,7 +101,11 @@
                     <bt:Image size="32" resid="Contoso.tpicon_32x32" />
                     <bt:Image size="80" resid="Contoso.tpicon_80x80" />
                   </Icon>
+
+                  <!-- This is what happens when the command is triggered (E.g. click on the Ribbon). Supported actions are ExecuteFunction or ShowTaskpane. -->
                   <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>ButtonId1</TaskpaneId>
+                    <!-- Provide a url resource id for the location that will be displayed on the task pane. -->
                     <SourceLocation resid="Contoso.Taskpane.Url" />
                   </Action>
                 </Control>
@@ -96,6 +116,7 @@
       </Host>
     </Hosts>
 
+    <!-- You can use resources across hosts and form factors. -->
     <Resources>
       <bt:Images>
         <bt:Image id="Contoso.tpicon_16x16" DefaultValue="https://localhost:3000/assets/Onedrive_Charts_icon_16x16px.png" />
@@ -107,11 +128,13 @@
         <bt:Url id="Contoso.GetStarted.LearnMoreUrl" DefaultValue="https://go.microsoft.com/fwlink/?LinkId=276812" />
         <bt:Url id="Contoso.DesktopFunctionFile.Url" DefaultValue="https://localhost:3000/function-file/function-file.html" />
       </bt:Urls>
+      <!-- ShortStrings max characters==125. -->
       <bt:ShortStrings>
         <bt:String id="Contoso.TaskpaneButton.Label" DefaultValue="Open Add-in" />
         <bt:String id="Contoso.Group1Label" DefaultValue="OneDrive Files" />
         <bt:String id="Contoso.GetStarted.Title" DefaultValue="Microsoft Graph data add-in has loaded successfully." />
       </bt:ShortStrings>
+      <!-- LongStrings max characters==250. -->
       <bt:LongStrings>
         <bt:String id="Contoso.TaskpaneButton.Tooltip" DefaultValue="Get files stored on OneDrive" />
         <bt:String id="Contoso.GetStarted.Description" DefaultValue="Choose Open Add-in, then Connect to Office 365 to get started." />

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,13 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<OfficeApp
-          xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
-          xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides"
-          xsi:type="TaskPaneApp">
-
-  <!-- Begin Basic Settings: Add-in metadata, used for all versions of Office unless override provided. -->
-
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
+  xmlns:mailappor="http://schemas.microsoft.com/office/mailappversionoverrides/1.0" xsi:type="MailApp">
   <!-- IMPORTANT! Id must be unique for your add-in, if you reuse this manifest ensure that you change this id to a new GUID. -->
   <Id>867f8385-2825-423d-a962-cde3417d5084</Id>
 
@@ -21,58 +16,51 @@
 
   <!-- Icon for your add-in. Used on installation screens and the add-ins dialog. -->
   <IconUrl DefaultValue="https://localhost:3000/assets/Onedrive_Charts_icon_32x32px.png" />
-  <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/hi-res-icon.png"/>
-
-  <!--If you plan to submit this add-in to the Office Store, uncomment the SupportUrl element below-->
-  <!--<SupportUrl DefaultValue="[Insert the URL of a page that provides support information for the app]">-->
-
-  <!-- Domains that will be allowed when navigating. For example, if you use ShowTaskpane and then have an href link, navigation will only be allowed if the domain is on this list. -->
+  <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/hi-res-icon.png"/>  <SupportUrl DefaultValue="https://www.contoso.com/help"/>
   <AppDomains>
-    <AppDomain>AppDomain1</AppDomain>
-    <AppDomain>AppDomain2</AppDomain>
-    <AppDomain>AppDomain3</AppDomain>
+    <AppDomain>https://localhost:3000</AppDomain>
   </AppDomains>
-  <!--End Basic Settings. -->
-
-  <!--Begin TaskPane Mode integration. This section is used if there are no VersionOverrides or if the Office client version does not support add-in commands. -->
   <Hosts>
-    <Host Name="Workbook" />
+    <Host Name="Mailbox"/>
   </Hosts>
-  <DefaultSettings>
-    <SourceLocation DefaultValue="https://localhost:3000/index.html" />
-  </DefaultSettings>
-  <!-- End TaskPane Mode integration.  -->
-
-  <Permissions>ReadWriteDocument</Permissions>
-
-  <!-- Begin Add-in Commands Mode integration. -->
-  <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
-
-    <!-- The Hosts node is required. -->
-    <Hosts>
-      <!-- Each host can have a different set of commands. -->
-      <!-- Excel host is Workbook, Word host is Document, and PowerPoint host is Presentation. -->
-      <!-- Make sure the hosts you override match the hosts declared in the top section of the manifest. -->
-      <Host xsi:type="Workbook">
-        <!-- Form factor. Currently only DesktopFormFactor is supported. -->
-        <DesktopFormFactor>
+  <Requirements>
+    <Sets>
+      <Set Name="Mailbox" MinVersion="1.1"/>
+    </Sets>
+  </Requirements>
+  <FormSettings>
+    <Form xsi:type="ItemRead">
+      <DesktopSettings>
+        <SourceLocation DefaultValue="https://localhost:3000/index.html" />
+        <RequestedHeight>250</RequestedHeight>
+      </DesktopSettings>
+    </Form>
+  </FormSettings>
+  <Permissions>ReadWriteMailbox</Permissions>
+  <Rule xsi:type="RuleCollection" Mode="Or">
+    <Rule xsi:type="ItemIs" ItemType="Message" FormType="Read"/>
+    <Rule xsi:type="ItemIs" ItemType="Appointment" FormType="Read"/>
+  </Rule>
+  <DisableEntityHighlighting>false</DisableEntityHighlighting>
+  <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
+    <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
+      <Requirements>
+        <bt:Sets DefaultMinVersion="1.12">
+          <bt:Set Name="Mailbox"/>
+        </bt:Sets>
+      </Requirements>
+      <Hosts>
+        <Host xsi:type="MailHost">
+          
+          <DesktopFormFactor>
           <!--"This code enables a customizable message to be displayed when the add-in is loaded successfully upon individual install."-->
-          <GetStarted>
-            <!-- Title of the Getting Started callout. resid points to a ShortString resource -->
-            <Title resid="Contoso.GetStarted.Title"/>
-
-            <!-- Description of the Getting Started callout. resid points to a LongString resource -->
-            <Description resid="Contoso.GetStarted.Description"/>
-
-            <!-- Point to a url resource which details how the add-in should be used. -->
-            <LearnMoreUrl resid="Contoso.GetStarted.LearnMoreUrl"/>
-          </GetStarted>
+        
           <!-- Function file is a HTML page that includes the JavaScript where functions for ExecuteAction will be called.
             Think of the FunctionFile as the code behind ExecuteFunction. -->
           <FunctionFile resid="Contoso.DesktopFunctionFile.Url" />
 
           <!-- PrimaryCommandSurface is the main Office Ribbon. -->
-          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+          <ExtensionPoint xsi:type="MessageReadCommandSurface">
             <!-- Use OfficeTab to extend an existing Tab. Use CustomTab to create a new tab. -->
             <OfficeTab id="TabHome">
               <!-- Ensure you provide a unique id for the group. Recommendation for any IDs is to namespace using your company name. -->
@@ -81,11 +69,7 @@
                 <Label resid="Contoso.Group1Label" />
                 <!-- Icons. Required sizes 16,32,80, optional 20, 24, 40, 48, 64. Strongly recommended to provide all sizes for great UX. -->
                 <!-- Use PNG icons. All URLs on the resources section must use HTTPS. -->
-                <Icon>
-                  <bt:Image size="16" resid="Contoso.tpicon_16x16" />
-                  <bt:Image size="32" resid="Contoso.tpicon_32x32" />
-                  <bt:Image size="80" resid="Contoso.tpicon_80x80" />
-                </Icon>
+                
 
                 <!-- Control. It can be of type "Button" or "Menu". -->
                 <Control xsi:type="Button" id="Contoso.TaskpaneButton">
@@ -104,7 +88,7 @@
 
                   <!-- This is what happens when the command is triggered (E.g. click on the Ribbon). Supported actions are ExecuteFunction or ShowTaskpane. -->
                   <Action xsi:type="ShowTaskpane">
-                    <TaskpaneId>ButtonId1</TaskpaneId>
+                    
                     <!-- Provide a url resource id for the location that will be displayed on the task pane. -->
                     <SourceLocation resid="Contoso.Taskpane.Url" />
                   </Action>
@@ -142,5 +126,5 @@
     </Resources>
   </VersionOverrides>
   <!-- End Add-in Commands Mode integration. -->
-
+</VersionOverrides>
 </OfficeApp>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,7 +9,7 @@ import SuccessPageBody from "./SuccessPageBody";
 import OfficeAddinMessageBar from "./OfficeAddinMessageBar";
 import { getGraphData } from "../../utilities/microsoft-graph-helpers";
 import {
-  writeFileNamesToWorksheet,
+  writeFileNamesToEmail,
   logoutFromO365,
   signInO365,
 } from "../../utilities/office-apis-helpers";
@@ -61,13 +61,13 @@ export default class App extends React.Component<AppProps, AppState> {
       primaryText: "Connects to OneDrive for Business.",
     },
     {
-      icon: "ExcelDocument",
+      icon: "Mail",
       primaryText:
         "Gets the names of the first three workbooks in OneDrive for Business.",
     },
     {
-      icon: "AddNotes",
-      primaryText: "Adds the names to the current document.",
+      icon: "Reply",
+      primaryText: "Adds the names to the reply of an email.",
     },
   ];
 
@@ -132,7 +132,7 @@ export default class App extends React.Component<AppProps, AppState> {
         "https://graph.microsoft.com/v1.0/me/drive/root/microsoft.graph.search(q = '.xlsx')?$select=name&top=3",
         this.accessToken
       );
-      await writeFileNamesToWorksheet(response, this.displayError);
+      await writeFileNamesToEmail(response, this.displayError);
       this.setState({ fileFetch: "fetched", headerMessage: "Success" });
     } catch (requestError) {
       // This error must be from the Axios request in getGraphData, 

--- a/src/components/GetDataPageBody.tsx
+++ b/src/components/GetDataPageBody.tsx
@@ -12,7 +12,7 @@ export default class GetDataPageBody extends React.Component<GetDataPageBodyProp
 
         return (
             <div className='ms-welcome__main'>
-                <h2 className='ms-font-xl ms-fontWeight-semilight ms-fontColor-neutralPrimary ms-u-slideUpIn20'>You can add data from Microsoft Graph to the document on this page.</h2>
+                <h2 className='ms-font-xl ms-fontWeight-semilight ms-fontColor-neutralPrimary ms-u-slideUpIn20'>You can add data from Microsoft Graph to the reply of an email on this page.</h2>
                 <Button className='ms-welcome__action' buttonType={ButtonType.hero} iconProps={{ iconName: 'ChevronRight' }} onClick={getFileNames}>Get File Names</Button>
                 <Button className='ms-welcome__action' buttonType={ButtonType.hero} iconProps={{ iconName: 'ChevronRight' }} onClick={logout}>Sign out from Office 365</Button>
             </div>

--- a/src/components/SuccessPageBody.tsx
+++ b/src/components/SuccessPageBody.tsx
@@ -12,7 +12,7 @@ export default class SuccessPageBody extends React.Component<SuccessPageBodyProp
 
         return (
             <div className='ms-welcome__main'>
-                <h2 className='ms-font-xl ms-fontWeight-semilight ms-fontColor-neutralPrimary ms-u-slideUpIn20'>The data has been added to the document.</h2>
+                <h2 className='ms-font-xl ms-fontWeight-semilight ms-fontColor-neutralPrimary ms-u-slideUpIn20'>The data has been added to the reply of the email.</h2>
                 <Button className='ms-welcome__action' buttonType={ButtonType.hero} iconProps={{ iconName: 'ChevronRight' }} onClick={getFileNames}>Get File Names</Button>
                 <Button className='ms-welcome__action' buttonType={ButtonType.hero} iconProps={{ iconName: 'ChevronRight' }} onClick={logout}>Sign out from Office 365</Button>
             </div>

--- a/utilities/office-apis-helpers.ts
+++ b/utilities/office-apis-helpers.ts
@@ -10,24 +10,9 @@ export const writeFileNamesToEmail = async (
     displayError: (x: string) => void
   ) => {
     try {
-      const item = Office.context.mailbox.item;
-  
-      // Extract the names from the result
-      const names = result.data.value.slice(0, 3).map((v) => v.name);
-  
-      // Convert names to Markdown list format
-      const markdown = names.map((name) => `- ${name}`).join('\n');
-  
-      // Set the reply body content to the Markdown text
-      item.body.setAsync(
-        markdown,
-        { coercionType: Office.CoercionType.Text },
-        (asyncResult) => {
-          if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-            displayError(asyncResult.error.message);
-          }
-        }
-      );
+      const names = result.data.value.slice(0, 3).map((item) => item.name);
+      const message = names.join('\n');
+      displayError(message);
     } catch (error) {
       displayError(error.toString());
     }

--- a/utilities/office-apis-helpers.ts
+++ b/utilities/office-apis-helpers.ts
@@ -5,29 +5,34 @@ import { AxiosResponse } from 'axios';
      Interacting with the Office document
 */
 
-export const writeFileNamesToWorksheet = async (result: AxiosResponse,
-    displayError: (x: string) => void) => {
-
+export const writeFileNamesToEmail = async (
+    result: AxiosResponse,
+    displayError: (x: string) => void
+  ) => {
     try {
-        await Excel.run((context: Excel.RequestContext) => {
-            const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-            const data = [
-                [result.data.value[0].name],
-                [result.data.value[1].name],
-                [result.data.value[2].name]];
-
-            const range = sheet.getRange('B5:B7');
-            range.values = data;
-            range.format.autofitColumns();
-
-            return context.sync();
-        });
+      const item = Office.context.mailbox.item;
+  
+      // Extract the names from the result
+      const names = result.data.value.slice(0, 3).map((v) => v.name);
+  
+      // Convert names to Markdown list format
+      const markdown = names.map((name) => `- ${name}`).join('\n');
+  
+      // Set the reply body content to the Markdown text
+      item.body.setAsync(
+        markdown,
+        { coercionType: Office.CoercionType.Text },
+        (asyncResult) => {
+          if (asyncResult.status === Office.AsyncResultStatus.Failed) {
+            displayError(asyncResult.error.message);
+          }
+        }
+      );
     } catch (error) {
-        displayError(error.toString());
+      displayError(error.toString());
     }
-};
-
+  };
+  
 /*
     Managing the dialogs.
 */
@@ -156,4 +161,3 @@ const processDialogEvent = (arg: { error: number, type: string },
             break;
     }
 };
-


### PR DESCRIPTION
This pull request modifies the functionality of the add-in to allow users to fetch filenames from OneDrive for Business and insert them into an email reply instead of an Excel document. The changes include updates to the messaging and method names to reflect this new functionality, ensuring a seamless user experience when interacting with Outlook. Additionally, the documentation has been updated to align with the new features.