### PR TITLE
Implement client secrets to have a working Graph API

### DIFF
--- a/appSettings.ts
+++ b/appSettings.ts
@@ -1,0 +1,13 @@
+export interface AppSettings {
+  clientId: string;
+  clientSecret: string;
+  tenantId: string;
+}
+
+const settings: AppSettings = {
+  clientId: 'YOUR_CLIENT_ID_HERE',
+  clientSecret: 'YOUR_CLIENT_SECRET_HERE',
+  tenantId: 'YOUR_TENANT_ID_HERE',
+};
+
+export default settings;

--- a/graphHelper.ts
+++ b/graphHelper.ts
@@ -1,0 +1,39 @@
+import 'isomorphic-fetch';
+import { ClientSecretCredential } from '@azure/identity';
+import { Client } from '@microsoft/microsoft-graph-client';
+import { TokenCredentialAuthenticationProvider } from '@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials';
+import settings from './appSettings';
+
+let _clientSecretCredential: ClientSecretCredential | undefined = undefined;
+let _appClient: Client | undefined = undefined;
+
+export function initializeGraphForAppOnlyAuth() {
+  if (!settings) {
+    throw new Error('Settings cannot be undefined');
+  }
+
+  _clientSecretCredential = new ClientSecretCredential(
+    settings.tenantId,
+    settings.clientId,
+    settings.clientSecret
+  );
+
+  const authProvider = new TokenCredentialAuthenticationProvider(_clientSecretCredential, {
+    scopes: ['https://graph.microsoft.com/.default'],
+  });
+
+  _appClient = Client.initWithMiddleware({ authProvider });
+}
+
+export async function getUsers() {
+  if (!_appClient) {
+    throw new Error('Graph has not been initialized for app-only auth');
+  }
+
+  return _appClient
+    .api('/users')
+    .select(['displayName', 'id', 'mail'])
+    .top(25)
+    .orderby('displayName')
+    .get();
+}

--- a/login/login.ts
+++ b/login/login.ts
@@ -4,11 +4,12 @@
  */
 
 import { PublicClientApplication } from "@azure/msal-browser";
+import settings from '../appSettings';
 
 Office.onReady(async () => {
   const pca = new PublicClientApplication({
     auth: {
-      clientId: '25cb9a5b-c5cf-4256-9c38-ce0ce1978167',
+      clientId: settings.clientId,
       authority: 'https://login.microsoftonline.com/common',
       redirectUri: `${window.location.origin}/login/login.html` // Must be registered as "spa" type.
     },

--- a/logout/logout.ts
+++ b/logout/logout.ts
@@ -4,6 +4,7 @@
  */
 
 import { PublicClientApplication } from '@azure/msal-browser';
+import settings from '../appSettings';
 
 let pca;
 
@@ -12,7 +13,7 @@ Office.onReady(async () => {
     onMessageFromParent);
   pca = new PublicClientApplication({
     auth: {
-      clientId: '25cb9a5b-c5cf-4256-9c38-ce0ce1978167',
+      clientId: settings.clientId,
       authority: 'https://login.microsoftonline.com/common',
       redirectUri: `${window.location.origin}/login/login.html` // Must be registered as "spa" type.
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,8 @@ import App from './components/App';
 import './styles.less';
 import 'office-ui-fabric-react/dist/css/fabric.min.css';
 
+import { initializeGraphForAppOnlyAuth } from './graphHelper';
+
 initializeIcons();
 
 let isOfficeInitialized = false;
@@ -26,6 +28,7 @@ const render = (Component) => {
 /* Render application after Office initializes */
 Office.initialize = () => {
     isOfficeInitialized = true;
+    initializeGraphForAppOnlyAuth();
     render(App);
 };
 


### PR DESCRIPTION
Fixes #17

Implement client secrets to have a working Graph API.

* **Add `appSettings.ts`**:
  - Create `AppSettings` interface with `clientId`, `clientSecret`, and `tenantId` properties.
  - Export a constant `settings` of type `AppSettings` with placeholder values.

* **Add `graphHelper.ts`**:
  - Import necessary modules including `isomorphic-fetch`, `ClientSecretCredential`, `Client`, `TokenCredentialAuthenticationProvider`, and `settings` from `appSettings`.
  - Define and export `initializeGraphForAppOnlyAuth` function to initialize the Graph client.
  - Define and export `getUsers` function to fetch users from the Graph API.

* **Modify `src/index.tsx`**:
  - Import and call `initializeGraphForAppOnlyAuth` from `graphHelper` in the `Office.initialize` function.

* **Modify `login/login.ts`**:
  - Update the `clientId` to match the `clientId` in `appSettings.ts`.

* **Modify `logout/logout.ts`**:
  - Update the `clientId` to match the `clientId` in `appSettings.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Wladefant/Office-Add-in-Microsoft-Graph-React/issues/17?shareId=43699fef-aaea-4cf8-aaa4-a8a7d4672d13).